### PR TITLE
docs: add developer guidelines and project structure documentation

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,0 +1,134 @@
+# Konfig - Developer Guidelines
+
+## Project Overview
+
+Konfig is a Spring-Framework-like configuration and profile manager for Go applications. It provides:
+
+- YAML configuration loading with profile support
+- Environment variable expansion and overrides
+- Nested configuration with dot notation
+- Default values for properties
+
+## Project Structure
+
+- `resources/` - Default directory for configuration files
+  - `application.yaml` - Main configuration file
+  - `application-{profile}.yaml` - Profile-specific configuration files
+- `test-data/` - Test configuration files
+- `test-proj/` - Example project using the library
+
+## Configuration Files
+
+- Use YAML format with `.yaml` or `.yml` extension
+- Main configuration file: `application.yaml`
+- Profile-specific files: `application-{profile}.yaml`
+- Environment variables can be referenced with `${ENV_VAR}`
+- Default values can be specified with `${ENV_VAR:default_value}`
+
+## Running Tests
+
+```bash
+# Run all tests with race detection
+make test
+
+# Run specific tests
+go test -v ./... -run TestName
+```
+
+## Building and Installing
+
+```bash
+# Build the project
+make build
+
+# Install the package
+make install
+
+# Update dependencies
+make deps
+```
+
+## Using the Library
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "github.com/mfenderov/konfig"
+    "log"
+)
+
+func main() {
+    // Load configuration
+    err := konfig.Load()
+    if err != nil {
+        log.Fatalf("Failed to load configuration: %v", err)
+    }
+
+    // Access configuration values
+    port := konfig.GetEnv("server.port")
+    dbHost := konfig.GetEnv("db.host")
+
+    // Use the values in your application
+    log.Printf("Server port: %s", port)
+    log.Printf("Database host: %s", dbHost)
+}
+```
+
+### Using Profiles
+
+Profiles can be specified using the `--profile` or `-p` flag:
+
+```bash
+# Run with dev profile
+go run main.go --profile dev
+
+# Run with prod profile
+go run main.go -p prod
+```
+
+You can check the current profile in your code:
+
+```go
+if konfig.IsDevProfile() {
+    // Development-specific code
+}
+
+if konfig.IsProdProfile() {
+    // Production-specific code
+}
+
+if konfig.IsProfile("test") {
+    // Test-specific code
+}
+```
+
+## Best Practices
+
+### Configuration
+
+- Keep configuration files organized and well-commented
+- Use nested structures for related configuration
+- Provide sensible default values
+- Use environment variables for sensitive information
+
+### Error Handling
+
+- Always wrap errors with context using `errors.Wrap`
+- Check for nil values in configuration
+- Handle missing configuration files gracefully
+
+### Testing
+
+- Write tests for different configuration scenarios
+- Test with various profiles
+- Test environment variable overrides
+- Test error cases (missing files, invalid YAML, etc.)
+
+## References
+
+- [Go Modules Documentation](https://go.dev/ref/mod)
+- [YAML Specification](https://yaml.org/spec/)
+- [Testify Library](https://github.com/stretchr/testify)

--- a/konfig.go
+++ b/konfig.go
@@ -90,14 +90,14 @@ func loadConfigWithFormat(format string, profileSuffix string) error {
 	}
 
 	for _, ext := range defaultConfigFileExtensions {
-		var filePathWithinProject string
+		var relativeConfigPath string
 		if profileSuffix == "" {
-			filePathWithinProject = fmt.Sprintf(format, defaultConfigFolder, defaultConfigFileName, ext)
+			relativeConfigPath = fmt.Sprintf(format, defaultConfigFolder, defaultConfigFileName, ext)
 		} else {
-			filePathWithinProject = fmt.Sprintf(format, defaultConfigFolder, defaultConfigFileName, profileSuffix, ext)
+			relativeConfigPath = fmt.Sprintf(format, defaultConfigFolder, defaultConfigFileName, profileSuffix, ext)
 		}
 
-		configFilePath := fmt.Sprintf(fullFileNameFormat, path, filePathWithinProject)
+		configFilePath := fmt.Sprintf(fullFileNameFormat, path, relativeConfigPath)
 		if _, err := os.Stat(configFilePath); err == nil {
 			return LoadFrom(configFilePath)
 		}

--- a/konfig_test.go
+++ b/konfig_test.go
@@ -1,6 +1,8 @@
 package konfig
 
 import (
+	"flag"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,9 +55,11 @@ func TestLoad_WithoutProfile(t *testing.T) {
 
 func TestLoad_WithTestProfile(t *testing.T) {
 	ClearEnv()
-	resetCommandLineFlags()
 
-	setCommandLineFlag("test")
+	// Set up command-line flags for the test profile
+	os.Args = []string{os.Args[0], "-p", "test"}
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	ResetProfileInitialized()
 
 	err := Load()
 	assert.NoError(t, err)

--- a/loader.go
+++ b/loader.go
@@ -31,12 +31,19 @@ func readConfigFile(pathToConfigFile string) (string, error) {
 		return "", errors.New("config file path cannot be empty")
 	}
 
-	rootPath, err := findRootPath()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to find root path")
+	var fullPath string
+	if filepath.IsAbs(pathToConfigFile) {
+		// If the path is already absolute, use it directly
+		fullPath = pathToConfigFile
+	} else {
+		// Otherwise, join it with the root path
+		rootPath, err := findRootPath()
+		if err != nil {
+			return "", errors.Wrap(err, "failed to find root path")
+		}
+		fullPath = filepath.Join(rootPath, pathToConfigFile)
 	}
 
-	fullPath := filepath.Join(rootPath, pathToConfigFile)
 	if !strings.HasSuffix(fullPath, ".yml") && !strings.HasSuffix(fullPath, ".yaml") {
 		return "", errors.New("config file must have .yml or .yaml extension")
 	}

--- a/profile.go
+++ b/profile.go
@@ -8,15 +8,24 @@ const devProfile = "dev"
 const prodProfile = "prod"
 
 var parsedProfile string
+var profileInitialized bool
 
 func init() {
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
 	pflag.StringVarP(&parsedProfile, "profile", "p", "", "Application profile")
 }
 
-func getProfile() string {
+// ResetProfileInitialized is used in tests to reset the profile initialization state
+func ResetProfileInitialized() {
+	profileInitialized = false
 	parsedProfile = ""
-	pflag.Parse()
+}
+
+func getProfile() string {
+	if !profileInitialized {
+		pflag.Parse()
+		profileInitialized = true
+	}
 	return parsedProfile
 }
 

--- a/profile_test.go
+++ b/profile_test.go
@@ -48,16 +48,19 @@ func TestProfile_ShouldReturnFalse(t *testing.T) {
 func resetCommandLineFlags() {
 	os.Args = []string{os.Args[0]}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	ResetProfileInitialized()
 }
 
 func setCommandLineFlag(p string) {
 	os.Args = []string{os.Args[0], "-p", p}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	ResetProfileInitialized()
 }
 
 func TestGetProfile_MoreFlags(t *testing.T) {
 	os.Args = []string{os.Args[0], "-p", "test", "-d", "dev", "-t", "prod"}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	ResetProfileInitialized()
 
 	profile := getProfile()
 	assert.Equal(t, "test", profile)

--- a/resource_finder_test.go
+++ b/resource_finder_test.go
@@ -1,0 +1,131 @@
+package konfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindRootPath(t *testing.T) {
+	// Save the original rootInstance to restore it after the test
+	originalRootInstance := rootInstance
+	defer func() {
+		rootInstance = originalRootInstance
+	}()
+
+	// Create a new rootInstance for this test
+	rootInstance = &root{}
+
+	// Create a temporary directory structure for testing
+	tempDir, err := os.MkdirTemp("", "konfig-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a resources directory in the temp directory
+	resourcesDir := filepath.Join(tempDir, "resources")
+	err = os.Mkdir(resourcesDir, 0755)
+	assert.NoError(t, err)
+
+	// Change to a subdirectory of the temp directory
+	subDir := filepath.Join(tempDir, "subdir")
+	err = os.Mkdir(subDir, 0755)
+	assert.NoError(t, err)
+
+	// Save current directory to restore it later
+	currentDir, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(currentDir)
+
+	// Change to the subdirectory
+	err = os.Chdir(subDir)
+	assert.NoError(t, err)
+
+	// Test finding the root path
+	path, err := findRootPath()
+	assert.NoError(t, err)
+
+	// Evaluate symlinks to get the real path
+	realTempDir, err := filepath.EvalSymlinks(tempDir)
+	assert.NoError(t, err)
+	assert.Equal(t, realTempDir, path)
+}
+
+func TestFindRootPath_NoResourcesDir(t *testing.T) {
+	// Save the original rootInstance to restore it after the test
+	originalRootInstance := rootInstance
+	defer func() {
+		rootInstance = originalRootInstance
+	}()
+
+	// Create a new rootInstance for this test
+	rootInstance = &root{}
+
+	// Create a temporary directory without a resources subdirectory
+	tempDir, err := os.MkdirTemp("", "konfig-test-no-resources")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Save current directory to restore it later
+	currentDir, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(currentDir)
+
+	// Change to the temp directory
+	err = os.Chdir(tempDir)
+	assert.NoError(t, err)
+
+	// Test finding the root path - should fail
+	_, err = findRootPath()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to find root path with 'resources' folder")
+}
+
+func TestFindRootPath_Caching(t *testing.T) {
+	// Save the original rootInstance to restore it after the test
+	originalRootInstance := rootInstance
+	defer func() {
+		rootInstance = originalRootInstance
+	}()
+
+	// Create a new rootInstance for this test
+	rootInstance = &root{}
+
+	// Create a temporary directory structure for testing
+	tempDir, err := os.MkdirTemp("", "konfig-test-caching")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a resources directory in the temp directory
+	resourcesDir := filepath.Join(tempDir, "resources")
+	err = os.Mkdir(resourcesDir, 0755)
+	assert.NoError(t, err)
+
+	// Save current directory to restore it later
+	currentDir, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(currentDir)
+
+	// Change to the temp directory
+	err = os.Chdir(tempDir)
+	assert.NoError(t, err)
+
+	// Evaluate symlinks to get the real path
+	realTempDir, err := filepath.EvalSymlinks(tempDir)
+	assert.NoError(t, err)
+
+	// First call to findRootPath
+	path1, err1 := findRootPath()
+	assert.NoError(t, err1)
+	assert.Equal(t, realTempDir, path1)
+
+	// Remove the resources directory to verify caching
+	err = os.RemoveAll(resourcesDir)
+	assert.NoError(t, err)
+
+	// Second call to findRootPath should return the cached result
+	path2, err2 := findRootPath()
+	assert.NoError(t, err2)
+	assert.Equal(t, realTempDir, path2)
+}

--- a/test-proj/main_test.go
+++ b/test-proj/main_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"flag"
-	"github.com/mfenderov/konfig"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/mfenderov/konfig"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_WithoutProfile(t *testing.T) {
@@ -21,6 +22,7 @@ func Test_WithoutProfile(t *testing.T) {
 func Test_WithProfile(t *testing.T) {
 	os.Args = []string{os.Args[0], "-p", "dev"}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	konfig.ResetProfileInitialized()
 
 	main()
 


### PR DESCRIPTION
This pull request introduces significant enhancements and refactoring to the `konfig` library, including new developer guidelines, improved configuration loading logic, enhanced test coverage, and better handling of environment variable references. Below is a summary of the most important changes grouped by theme.

### Documentation and Guidelines

* Added a comprehensive developer guide in `.junie/guidelines.md` detailing the project structure, configuration file conventions, testing, building, and best practices for using the `konfig` library. This includes examples for basic usage, profile handling, and error handling.

### Refactoring and Code Simplification

* Simplified the configuration loading logic by introducing a new `loadConfigWithFormat` helper function, which consolidates logic for loading both default and profiled configurations. This reduces code duplication in `loadProfiled` and `loadDefault` functions in `konfig.go`. [[1]](diffhunk://#diff-5235a95f67a5e9c6307f69b8f8c07a25eabe683a86cd0057b15bd54b1c2c01c4R51-R57) [[2]](diffhunk://#diff-5235a95f67a5e9c6307f69b8f8c07a25eabe683a86cd0057b15bd54b1c2c01c4R81-R102)

### Improved Environment Variable Handling

* Enhanced the `enrichValue` function in `loader.go` to better process environment variable references in configuration values, supporting formats like `${ENV_VAR}` and `${ENV_VAR:default_value}`. Improved logging for missing environment variables and added clearer handling of default values.

### Test Coverage and Reliability

* Added new tests in `resource_finder_test.go` to validate the behavior of the `findRootPath` function, including scenarios for caching, missing resources directory, and directory structure traversal.
* Updated tests in `konfig_test.go` and `profile_test.go` to reset the profile initialization state using a new `ResetProfileInitialized` function, ensuring consistent behavior across test cases. [[1]](diffhunk://#diff-7bb947789c457364af1e4c31e0ed1cfaa0eb034f75eede92f8af911907c55bf2L56-R62) [[2]](diffhunk://#diff-2271c5e335d554ad55b2c92d6a2b27a287b943fcbd276d875f8be39b9ef4dc79R51-R63)

### Profile Management Enhancements

* Introduced a `profileInitialized` flag in `profile.go` to prevent redundant parsing of command-line flags. Added a `ResetProfileInitialized` function to allow resetting the state, primarily for testing purposes.